### PR TITLE
Fix Cloudflare deployment by updating compatibility_date

### DIFF
--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -1,6 +1,6 @@
 name = "reading-list"
 main = "worker.js"
-compatibility_date = "2024-04-01"
+compatibility_date = "2026-04-18"
 
 [assets]
 directory = "./out"


### PR DESCRIPTION
This PR updates the `compatibility_date` in `cloudflare/wrangler.toml` to `2026-04-18`. The project uses the Cloudflare Workers "Static Assets" feature (via the `[assets]` configuration block), which requires a modern compatibility date to be processed correctly by Wrangler during deployment. The previous date (`2024-04-01`) was causing the deployment to fail with an exit code 1.

Changes:
- Updated `compatibility_date` in `cloudflare/wrangler.toml` to `2026-04-18`.

Verification:
- Confirmed the required date from Cloudflare documentation.
- Ran `npm run test` to ensure no regressions.

Fixes #134

---
*PR created automatically by Jules for task [8895153837030387282](https://jules.google.com/task/8895153837030387282) started by @ifireball*