### PR TITLE
Document public URL and configure custom domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -184,6 +184,7 @@ jobs:
 
             const success = authorized && wranglerOutcome === 'success' && !!deploymentUrl;
             const failure = authorized && (wranglerOutcome === 'failure' || (wranglerOutcome === 'success' && !deploymentUrl));
+            const finalDeploymentUrl = success && !isPR ? 'https://reading-list.korren.org/' : deploymentUrl;
 
             if (targetSha) {
               // Update Commit Status
@@ -194,7 +195,7 @@ jobs:
                 state: success ? 'success' : (failure ? 'failure' : 'pending'),
                 context: 'Cloudflare Workers Deployment',
                 description: success ? 'Deployed successfully!' : (failure ? 'Deployment failed.' : 'Pending authorization.'),
-                target_url: success ? deploymentUrl : (failure ? logUrl : undefined)
+                target_url: success ? finalDeploymentUrl : (failure ? logUrl : undefined)
               });
             }
 
@@ -214,7 +215,7 @@ jobs:
                 repo: context.repo.repo,
                 deployment_id: deployment.id,
                 state: 'success',
-                environment_url: deploymentUrl,
+                environment_url: finalDeploymentUrl,
                 log_url: logUrl
               });
             }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # reading-list
+The site is available at [https://reading-list.korren.org/](https://reading-list.korren.org/)
+
 List of stuff I read.
 
 This repository contains a Next.js application that renders a reading list from a collection of YAML files.

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -5,3 +5,7 @@ compatibility_date = "2026-04-18"
 [assets]
 directory = "./out"
 binding = "ASSETS"
+
+[[routes]]
+pattern = "reading-list.korren.org"
+custom_domain = true


### PR DESCRIPTION
I have documented the public URL for the site in the README and configured the deployment pipeline to use it for production. Specifically, I added the URL to `README.md`, configured the `[[routes]]` in `cloudflare/wrangler.toml` for the custom domain, and updated the GitHub Actions deployment script to report the correct URL for production deployments while maintaining dynamic preview URLs for pull requests.

Fixes #137

---
*PR created automatically by Jules for task [18293857166378795180](https://jules.google.com/task/18293857166378795180) started by @ifireball*