### PR TITLE
🧹 Move static array outside of Columns component

### DIFF
--- a/components/columns.jsx
+++ b/components/columns.jsx
@@ -1,9 +1,10 @@
 import css from './columns.module.scss'
 
+const COLUMNS = ["To Read", "Reading", "Read"]
+
 export default function Columns({ data }) {
-    const columns = ["To Read", "Reading", "Read"]
     return <div className={css.columns}>
-        {columns.map((col) => <Column
+        {COLUMNS.map((col) => <Column
             key={col}
             title={col}
             items={data.filter(({status}) => status.toLowerCase() === col.toLowerCase())}


### PR DESCRIPTION
🎯 **What:** Moved the `columns` array outside of the `Columns` component function and renamed it to `COLUMNS`.
💡 **Why:** Preventing the array from being recreated on every render is a simple performance optimization and improves code readability.
✅ **Verification:** The change was manually verified via `read_file`. Automated tests could not be run due to persistent environment issues (`npm install` timeouts), but the refactoring is extremely low-risk and has been confirmed as correct in code review.
✨ **Result:** Improved component performance and followed standard constant naming conventions.

---
*PR created automatically by Jules for task [984633605630191968](https://jules.google.com/task/984633605630191968) started by @ifireball*