### PR TITLE
Update README for recent tech stack changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,19 @@ The site is available at [https://reading-list.korren.org/](https://reading-list
 
 List of stuff I read.
 
-This repository contains a Next.js application that renders a reading list from a collection of YAML files.
+This repository contains a SvelteKit application that renders a reading list from a collection of YAML files.
+
+## Prerequisites
+- **Node.js**: >= 24.15.0 (managed by [mise](https://mise.jdx.dev/))
+- **npm**: Included with Node.js
 
 ## Data
 The reading list data is stored as YAML files in the `data/` directory. The data is validated against a JSON schema (`data/schema.json`) using Ajv. You can run the validation script using `./bin/validate.js`.
 
 ## Tech Stack
-* Next.js
-* React
-* Sass
-* Vitest for testing
+* [SvelteKit](https://kit.svelte.dev/) (Svelte 5)
+* [Sass](https://sass-lang.com/)
+* [Vitest](https://vitest.dev/) for testing
 
 ## Development
 To run the development server:
@@ -25,3 +28,6 @@ To run the tests:
 ```bash
 npm run test
 ```
+
+## Deployment
+See [CLOUDFLARE.md](CLOUDFLARE.md) for details on how this project is deployed to Cloudflare Workers.


### PR DESCRIPTION
Updated the README.md to accurately reflect the current technology stack of the project, which has been migrated from Next.js to SvelteKit with Svelte 5. The update also includes information about the required Node.js version, tool management with mise, and a pointer to the Cloudflare deployment documentation.

Fixes #13

---
*PR created automatically by Jules for task [2830373309719893981](https://jules.google.com/task/2830373309719893981) started by @ifireball*