### PR TITLE
Trigger build on allow-deploy label changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,17 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && (
+        (github.event.action != 'labeled' && github.event.action != 'unlabeled') ||
+        github.event.label.name == 'allow-deploy'
+      ))
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This change ensures that the CI/CD deployment pipeline is triggered when the `allow-deploy` label is added to or removed from a Pull Request.

Since the `deploy.yml` workflow is triggered by `workflow_run` on the `Build` workflow, the `Build` workflow must run when the label changes for the deployment authorization to take effect immediately.

Changes:
- Added `labeled` and `unlabeled` to `on.pull_request.types` in `.github/workflows/build.yml`.
- Added a job-level `if` condition to the `build` job to:
    - Always run on `push` events.
    - Run on standard `pull_request` events (opened, synchronize, reopened).
    - Only run on `labeled` or `unlabeled` events if the affected label is `allow-deploy`.

Fixes #157

---
*PR created automatically by Jules for task [9177508617722163895](https://jules.google.com/task/9177508617722163895) started by @ifireball*