### PR TITLE
🔒 [security fix] Sanitize link URLs to prevent XSS

### DIFF
--- a/src/lib/components/Item.svelte
+++ b/src/lib/components/Item.svelte
@@ -1,9 +1,11 @@
 <script>
+    import { sanitizeUrl } from '$lib/security';
+
     export let item;
     const { title, url, notes } = item;
 </script>
 
 <article>
-    <h3><a href={url}>{title}</a></h3>
+    <h3><a href={sanitizeUrl(url)}>{title}</a></h3>
     <div>{@html notes}</div>
 </article>

--- a/src/lib/security.js
+++ b/src/lib/security.js
@@ -1,0 +1,28 @@
+/**
+ * Sanitizes a URL to prevent XSS attacks.
+ * It only allows safe protocols (http, https, mailto, tel) or relative paths.
+ *
+ * @param {any} url - The URL to sanitize.
+ * @returns {string} - The sanitized URL or 'about:blank' if unsafe.
+ */
+export function sanitizeUrl(url) {
+    if (url === null || url === undefined) return '';
+
+    const sanitized = String(url).trim();
+
+    if (sanitized === '') return '';
+
+    // Allow relative paths
+    if (sanitized.startsWith('/') || sanitized.startsWith('./') || sanitized.startsWith('../')) {
+        return sanitized;
+    }
+
+    // Allow safe protocols
+    const safeProtocolPattern = /^(https?|mailto|tel):/i;
+    if (safeProtocolPattern.test(sanitized)) {
+        return sanitized;
+    }
+
+    // Default to about:blank for potentially dangerous schemes (like javascript:)
+    return 'about:blank';
+}

--- a/src/lib/security.js
+++ b/src/lib/security.js
@@ -12,8 +12,14 @@ export function sanitizeUrl(url) {
 
     if (sanitized === '') return '';
 
-    // Allow relative paths
-    if (sanitized.startsWith('/') || sanitized.startsWith('./') || sanitized.startsWith('../')) {
+    // Allow relative paths, anchors, and query-only URLs
+    if (
+        sanitized.startsWith('/') ||
+        sanitized.startsWith('./') ||
+        sanitized.startsWith('../') ||
+        sanitized.startsWith('#') ||
+        sanitized.startsWith('?')
+    ) {
         return sanitized;
     }
 

--- a/src/lib/security.test.js
+++ b/src/lib/security.test.js
@@ -1,37 +1,41 @@
+import { describe, it, expect } from 'vitest';
 import { sanitizeUrl } from './security.js';
 
-const testCases = [
-    { input: 'https://example.com', expected: 'https://example.com', desc: 'Secure HTTP' },
-    { input: 'http://example.com', expected: 'http://example.com', desc: 'Standard HTTP' },
-    { input: 'mailto:user@example.com', expected: 'mailto:user@example.com', desc: 'Mailto scheme' },
-    { input: 'tel:+123456789', expected: 'tel:+123456789', desc: 'Tel scheme' },
-    { input: '/local/path', expected: '/local/path', desc: 'Absolute local path' },
-    { input: './local/path', expected: './local/path', desc: 'Relative local path' },
-    { input: '../local/path', expected: '../local/path', desc: 'Parent local path' },
-    { input: 'javascript:alert(1)', expected: 'about:blank', desc: 'Javascript scheme' },
-    { input: 'JAVASCRIPT:alert(1)', expected: 'about:blank', desc: 'Case-insensitive Javascript scheme' },
-    { input: ' data:text/html,<html>', expected: 'about:blank', desc: 'Data scheme' },
-    { input: 'vbscript:msgbox("hello")', expected: 'about:blank', desc: 'VBScript scheme' },
-    { input: '   https://example.com   ', expected: 'https://example.com', desc: 'Trimmed whitespace' },
-    { input: '', expected: '', desc: 'Empty string' },
-    { input: null, expected: '', desc: 'Null input' },
-];
+describe('sanitizeUrl', () => {
+    it('allows safe protocols', () => {
+        expect(sanitizeUrl('https://example.com')).toBe('https://example.com');
+        expect(sanitizeUrl('http://example.com')).toBe('http://example.com');
+        expect(sanitizeUrl('mailto:user@example.com')).toBe('mailto:user@example.com');
+        expect(sanitizeUrl('tel:+123456789')).toBe('tel:+123456789');
+    });
 
-let failed = 0;
-testCases.forEach(({ input, expected, desc }) => {
-    const result = sanitizeUrl(input);
-    if (result === expected) {
-        console.log(`✅ PASS: ${desc}`);
-    } else {
-        console.log(`❌ FAIL: ${desc} - Expected "${expected}", got "${result}"`);
-        failed++;
-    }
+    it('allows relative paths, anchors, and queries', () => {
+        expect(sanitizeUrl('/local/path')).toBe('/local/path');
+        expect(sanitizeUrl('./local/path')).toBe('./local/path');
+        expect(sanitizeUrl('../local/path')).toBe('../local/path');
+        expect(sanitizeUrl('#anchor')).toBe('#anchor');
+        expect(sanitizeUrl('?query=1')).toBe('?query=1');
+    });
+
+    it('blocks dangerous schemes', () => {
+        expect(sanitizeUrl('javascript:alert(1)')).toBe('about:blank');
+        expect(sanitizeUrl('JAVASCRIPT:alert(1)')).toBe('about:blank');
+        expect(sanitizeUrl('data:text/html,<html>')).toBe('about:blank');
+        expect(sanitizeUrl('vbscript:msgbox("hello")')).toBe('about:blank');
+    });
+
+    it('handles whitespace', () => {
+        expect(sanitizeUrl('   https://example.com   ')).toBe('https://example.com');
+    });
+
+    it('handles empty or null input', () => {
+        expect(sanitizeUrl('')).toBe('');
+        expect(sanitizeUrl(null)).toBe('');
+        expect(sanitizeUrl(undefined)).toBe('');
+    });
+
+    it('handles non-string input gracefully', () => {
+        expect(sanitizeUrl(123)).toBe('about:blank');
+        expect(sanitizeUrl(true)).toBe('about:blank');
+    });
 });
-
-if (failed === 0) {
-    console.log('\nAll tests passed!');
-    process.exit(0);
-} else {
-    console.log(`\n${failed} tests failed.`);
-    process.exit(1);
-}

--- a/src/lib/security.test.js
+++ b/src/lib/security.test.js
@@ -1,0 +1,37 @@
+import { sanitizeUrl } from './security.js';
+
+const testCases = [
+    { input: 'https://example.com', expected: 'https://example.com', desc: 'Secure HTTP' },
+    { input: 'http://example.com', expected: 'http://example.com', desc: 'Standard HTTP' },
+    { input: 'mailto:user@example.com', expected: 'mailto:user@example.com', desc: 'Mailto scheme' },
+    { input: 'tel:+123456789', expected: 'tel:+123456789', desc: 'Tel scheme' },
+    { input: '/local/path', expected: '/local/path', desc: 'Absolute local path' },
+    { input: './local/path', expected: './local/path', desc: 'Relative local path' },
+    { input: '../local/path', expected: '../local/path', desc: 'Parent local path' },
+    { input: 'javascript:alert(1)', expected: 'about:blank', desc: 'Javascript scheme' },
+    { input: 'JAVASCRIPT:alert(1)', expected: 'about:blank', desc: 'Case-insensitive Javascript scheme' },
+    { input: ' data:text/html,<html>', expected: 'about:blank', desc: 'Data scheme' },
+    { input: 'vbscript:msgbox("hello")', expected: 'about:blank', desc: 'VBScript scheme' },
+    { input: '   https://example.com   ', expected: 'https://example.com', desc: 'Trimmed whitespace' },
+    { input: '', expected: '', desc: 'Empty string' },
+    { input: null, expected: '', desc: 'Null input' },
+];
+
+let failed = 0;
+testCases.forEach(({ input, expected, desc }) => {
+    const result = sanitizeUrl(input);
+    if (result === expected) {
+        console.log(`✅ PASS: ${desc}`);
+    } else {
+        console.log(`❌ FAIL: ${desc} - Expected "${expected}", got "${result}"`);
+        failed++;
+    }
+});
+
+if (failed === 0) {
+    console.log('\nAll tests passed!');
+    process.exit(0);
+} else {
+    console.log(`\n${failed} tests failed.`);
+    process.exit(1);
+}


### PR DESCRIPTION
🎯 **What:** This PR fixes a Cross-Site Scripting (XSS) vulnerability in the `Item.svelte` component.

⚠️ **Risk:** Malicious `javascript:` URIs could be provided in the reading list data, which would then be rendered unsanitized in the `href` attribute of links. This could allow an attacker to execute arbitrary JavaScript in the user's browser when they click on the link.

🛡️ **Solution:** Introduced a `sanitizeUrl` utility that enforces an allowlist of safe URI schemes (`http`, `https`, `mailto`, `tel`) and relative paths. Any unsafe URL is replaced with `about:blank`. This utility is now applied to all item links in `Item.svelte`.

The fix was verified with a new test suite in `src/lib/security.test.js` covering various attack vectors and edge cases.

---
*PR created automatically by Jules for task [1550542644446596645](https://jules.google.com/task/1550542644446596645) started by @ifireball*