### PR TITLE
🧹 [Code Health] Change 'var' to 'let' in load-data.js

### DIFF
--- a/src/lib/load-data.js
+++ b/src/lib/load-data.js
@@ -33,7 +33,7 @@ export async function validateData() {
     const schemaFile = path.join(dataPath, "schema.json")
     const schema = JSON.parse(await fs.readFile(schemaFile, 'utf-8'))
     const validate = ajv.compile(schema)
-    var allPassed = true
+    let allPassed = true
 
     const yamlFiles = await listYamlFiles()
     const results = await Promise.all(yamlFiles.map(async (file) => {


### PR DESCRIPTION
🎯 **What:** Changed `var` to `let` for the `allPassed` variable in `src/lib/load-data.js`.
💡 **Why:** `let` is a block-scoped variable that avoids accidental variable hoisting and shadowing issues that can occur with `var`. `allPassed` is later reassigned in the validation loop, making `let` the appropriate choice rather than `const`.
✅ **Verification:** Verified by running the vitest test suite via `npm run test` which shows all 4 existing tests in `src/lib/load-data.test.js` continue to pass. Verified via `npm run build` that the project still builds.
✨ **Result:** Modernized JavaScript variable declarations ensuring block-level scoping and adherence to contemporary JavaScript standards without changing existing behavior.

---
*PR created automatically by Jules for task [10240559627627205632](https://jules.google.com/task/10240559627627205632) started by @ifireball*