### PR TITLE
🔒 Enable HTML sanitization in load-data.js to prevent XSS

### DIFF
--- a/pr-body.md
+++ b/pr-body.md
@@ -1,0 +1,8 @@
+🎯 **What:**
+The vulnerability fixed is a potential Cross-Site Scripting (XSS) vulnerability via unescaped HTML. Svelte's `{@html notes}` in `src/lib/components/Item.svelte` renders raw HTML, and previously the Markdown parser used to populate `notes` (`remark-html` in `src/lib/load-data.js`) did not sanitize the HTML output.
+
+⚠️ **Risk:**
+If left unfixed, this vulnerability could allow an attacker who controls the YAML data to inject arbitrary HTML or JavaScript (e.g., `<script>alert(1)</script>`) into the application. Since `{@html}` bypasses Svelte's built-in XSS protections, the injected script would be executed in the user's browser, potentially leading to session hijacking, defacement, or unauthorized actions on behalf of the user.
+
+🛡️ **Solution:**
+The fix addresses the vulnerability by enabling sanitization in the Markdown parser. By passing `{ sanitize: true }` to `remark-html` when instantiating the plugin in `src/lib/load-data.js`, the parsed HTML is now sanitized before it is ever stored or passed to the Svelte components. This strips out dangerous tags and attributes (like `<script>`) while preserving safe formatting (like `<strong>` and `<em>`). A test case was also added to ensure that `<script>` tags are successfully removed.

--- a/pr-body.md
+++ b/pr-body.md
@@ -1,8 +1,0 @@
-🎯 **What:**
-The vulnerability fixed is a potential Cross-Site Scripting (XSS) vulnerability via unescaped HTML. Svelte's `{@html notes}` in `src/lib/components/Item.svelte` renders raw HTML, and previously the Markdown parser used to populate `notes` (`remark-html` in `src/lib/load-data.js`) did not sanitize the HTML output.
-
-⚠️ **Risk:**
-If left unfixed, this vulnerability could allow an attacker who controls the YAML data to inject arbitrary HTML or JavaScript (e.g., `<script>alert(1)</script>`) into the application. Since `{@html}` bypasses Svelte's built-in XSS protections, the injected script would be executed in the user's browser, potentially leading to session hijacking, defacement, or unauthorized actions on behalf of the user.
-
-🛡️ **Solution:**
-The fix addresses the vulnerability by enabling sanitization in the Markdown parser. By passing `{ sanitize: true }` to `remark-html` when instantiating the plugin in `src/lib/load-data.js`, the parsed HTML is now sanitized before it is ever stored or passed to the Svelte components. This strips out dangerous tags and attributes (like `<script>`) while preserving safe formatting (like `<strong>` and `<em>`). A test case was also added to ensure that `<script>` tags are successfully removed.

--- a/src/lib/load-data.js
+++ b/src/lib/load-data.js
@@ -7,7 +7,7 @@ import Ajv from 'ajv'
 import addFormats from 'ajv-formats'
 
 const ajv = new Ajv({verbose: true, allErrors: true})
-const remarkProcessor = remark().use(html)
+const remarkProcessor = remark().use(html, { sanitize: true })
 addFormats(ajv)
 const dataPath = path.join(process.cwd(), "data")
 

--- a/src/lib/load-data.test.js
+++ b/src/lib/load-data.test.js
@@ -38,7 +38,7 @@ describe('load-data', () => {
 title: The Book
 url: http://example.com/1
 status: To Read
-notes: This is **bold** text
+notes: This is **bold** text and a <script>alert(1)</script> tag
 `)
         }
         if (filePath.endsWith('book2.yaml')) {
@@ -60,6 +60,7 @@ notes: Just a note
       expect(book1.url).toBe('http://example.com/1')
       expect(book1.status).toBe('To Read')
       expect(book1.notes).toContain('<strong>bold</strong>')
+      expect(book1.notes).not.toContain('<script>')
 
       const book2 = data.find(item => item.key === 'book2.yaml')
       expect(book2.title).toBe('Second Book')


### PR DESCRIPTION
🎯 **What:** 
The vulnerability fixed is a potential Cross-Site Scripting (XSS) vulnerability via unescaped HTML. Svelte's `{@html notes}` in `src/lib/components/Item.svelte` renders raw HTML, and previously the Markdown parser used to populate `notes` (`remark-html` in `src/lib/load-data.js`) did not sanitize the HTML output.

⚠️ **Risk:** 
If left unfixed, this vulnerability could allow an attacker who controls the YAML data to inject arbitrary HTML or JavaScript (e.g., `<script>alert(1)</script>`) into the application. Since `{@html}` bypasses Svelte's built-in XSS protections, the injected script would be executed in the user's browser, potentially leading to session hijacking, defacement, or unauthorized actions on behalf of the user.

🛡️ **Solution:** 
The fix addresses the vulnerability by enabling sanitization in the Markdown parser. By passing `{ sanitize: true }` to `remark-html` when instantiating the plugin in `src/lib/load-data.js`, the parsed HTML is now sanitized before it is ever stored or passed to the Svelte components. This strips out dangerous tags and attributes (like `<script>`) while preserving safe formatting (like `<strong>` and `<em>`). A test case was also added to ensure that `<script>` tags are successfully removed.

---
*PR created automatically by Jules for task [14014196895778800951](https://jules.google.com/task/14014196895778800951) started by @ifireball*