### PR TITLE
🧹 Remove extraneous console.log in listYamlFiles

### DIFF
--- a/src/lib/load-data.js
+++ b/src/lib/load-data.js
@@ -12,7 +12,6 @@ addFormats(ajv)
 const dataPath = path.join(process.cwd(), "data")
 
 async function listYamlFiles() {
-    console.log(`Loading data from: ${dataPath}`)
     const filesInData = await fs.readdir(dataPath)
     return filesInData
         .filter((f) => f.endsWith('.yaml'))


### PR DESCRIPTION
🎯 **What:** Removed the `console.log` statement that outputs the data path in `src/lib/load-data.js`.
💡 **Why:** Reduces noise in application logs and improves code cleanliness without affecting any functionality.
✅ **Verification:** Ran `npm run test` and `npm run test:coverage` locally. Tests successfully pass and coverage stays at 100%.
✨ **Result:** Cleaner `load-data.js` with improved maintainability and no loss of function.

---
*PR created automatically by Jules for task [7013570255818775970](https://jules.google.com/task/7013570255818775970) started by @ifireball*